### PR TITLE
Clean-up of error handing in startup functions

### DIFF
--- a/esp32-fdr.ino
+++ b/esp32-fdr.ino
@@ -9,147 +9,166 @@
 
 #include "appGlobals.h"
 
+#include <sstream>
+#include <iomanip>
+#include <stdexcept>
+
+
 char camModel[10];
 
 static void prepCam() {
-  // initialise camera depending on model and board
-  // configure camera
-  camera_config_t config;
-  config.ledc_channel = LEDC_CHANNEL_0;
-  config.ledc_timer = LEDC_TIMER_0;
-  config.pin_d0 = Y2_GPIO_NUM;
-  config.pin_d1 = Y3_GPIO_NUM;
-  config.pin_d2 = Y4_GPIO_NUM;
-  config.pin_d3 = Y5_GPIO_NUM;
-  config.pin_d4 = Y6_GPIO_NUM;
-  config.pin_d5 = Y7_GPIO_NUM;
-  config.pin_d6 = Y8_GPIO_NUM;
-  config.pin_d7 = Y9_GPIO_NUM;
-  config.pin_xclk = XCLK_GPIO_NUM;
-  config.pin_pclk = PCLK_GPIO_NUM;
-  config.pin_vsync = VSYNC_GPIO_NUM;
-  config.pin_href = HREF_GPIO_NUM;
-  config.pin_sccb_sda = SIOD_GPIO_NUM;
-  config.pin_sccb_scl = SIOC_GPIO_NUM;
-  config.pin_pwdn = PWDN_GPIO_NUM;
-  config.pin_reset = RESET_GPIO_NUM;
-  config.xclk_freq_hz = xclkMhz * 1000000;
-  config.pixel_format = PIXFORMAT_JPEG;
-  config.grab_mode = CAMERA_GRAB_LATEST;
-  // init with high specs to pre-allocate larger buffers
-  config.fb_location = CAMERA_FB_IN_PSRAM;
+    // initialise camera depending on model and board
+    // configure camera
+    camera_config_t config;
+    config.ledc_channel = LEDC_CHANNEL_0;
+    config.ledc_timer = LEDC_TIMER_0;
+    config.pin_d0 = Y2_GPIO_NUM;
+    config.pin_d1 = Y3_GPIO_NUM;
+    config.pin_d2 = Y4_GPIO_NUM;
+    config.pin_d3 = Y5_GPIO_NUM;
+    config.pin_d4 = Y6_GPIO_NUM;
+    config.pin_d5 = Y7_GPIO_NUM;
+    config.pin_d6 = Y8_GPIO_NUM;
+    config.pin_d7 = Y9_GPIO_NUM;
+    config.pin_xclk = XCLK_GPIO_NUM;
+    config.pin_pclk = PCLK_GPIO_NUM;
+    config.pin_vsync = VSYNC_GPIO_NUM;
+    config.pin_href = HREF_GPIO_NUM;
+    config.pin_sccb_sda = SIOD_GPIO_NUM;
+    config.pin_sccb_scl = SIOC_GPIO_NUM;
+    config.pin_pwdn = PWDN_GPIO_NUM;
+    config.pin_reset = RESET_GPIO_NUM;
+    config.xclk_freq_hz = xclkMhz * 1000000;
+    config.pixel_format = PIXFORMAT_JPEG;
+    config.grab_mode = CAMERA_GRAB_LATEST;
+    // init with high specs to pre-allocate larger buffers
+    config.fb_location = CAMERA_FB_IN_PSRAM;
 #if CONFIG_IDF_TARGET_ESP32S3
-  config.frame_size = FRAMESIZE_QSXGA; // 8M
+    config.frame_size = FRAMESIZE_QSXGA; // 8M
 #else
-  config.frame_size = FRAMESIZE_UXGA;  // 4M
+    config.frame_size = FRAMESIZE_UXGA;  // 4M
 #endif  
-  config.jpeg_quality = 10;
-  config.fb_count = 4;
+    config.jpeg_quality = 10;
+    config.fb_count = 4;
 
 #if defined(CAMERA_MODEL_ESP_EYE)
-  pinMode(13, INPUT_PULLUP);
-  pinMode(14, INPUT_PULLUP);
+    pinMode(13, INPUT_PULLUP);
+    pinMode(14, INPUT_PULLUP);
 #endif
 
-  // camera init
-  if (psramFound()) {
-    esp_err_t err = ESP_FAIL;
-    uint8_t retries = 2;
-    while (retries && err != ESP_OK) {
-      err = esp_camera_init(&config);
-      if (err != ESP_OK) {
-        // power cycle the camera, provided pin is connected
-        digitalWrite(PWDN_GPIO_NUM, 1);
-        delay(100);
-        digitalWrite(PWDN_GPIO_NUM, 0); 
-        delay(100);
-        retries--;
-      }
-    } 
-    if (err != ESP_OK) sprintf(startupFailure, "Startup Failure: Camera init error 0x%x", err);
-    else {
-      sensor_t * s = esp_camera_sensor_get();
-      switch (s->id.PID) {
-        case (OV2640_PID):
-          strcpy(camModel, "OV2640");
-        break;
-        case (OV3660_PID):
-          strcpy(camModel, "OV3660");
-        break;
-        case (OV5640_PID):
-          strcpy(camModel, "OV5640");
-        break;
-        default:
-          strcpy(camModel, "Other");
-        break;
-      }
-      LOG_INF("Camera init OK for model %s on board %s", camModel, CAM_BOARD);
+    // camera init
+    if (psramFound()) {
+        esp_err_t err = ESP_FAIL;
+        uint8_t retries = 2;
+        while (retries && err != ESP_OK) {
+            err = esp_camera_init(&config);
+            if (err != ESP_OK) {
+                // power cycle the camera, provided pin is connected
+                digitalWrite(PWDN_GPIO_NUM, 1);
+                delay(100);
+                digitalWrite(PWDN_GPIO_NUM, 0); 
+                delay(100);
+                retries--;
+            }
+        } 
 
-      // model specific corrections
-      if (s->id.PID == OV3660_PID) {
-        // initial sensors are flipped vertically and colors are a bit saturated
-        s->set_vflip(s, 1);//flip it back
-        s->set_brightness(s, 1);//up the brightness just a bit
-        s->set_saturation(s, -2);//lower the saturation
-      }
-      // set frame size to configured value
-      char fsizePtr[4];
-      if (retrieveConfigVal("framesize", fsizePtr)) s->set_framesize(s, (framesize_t)(atoi(fsizePtr)));
-      else s->set_framesize(s, FRAMESIZE_SVGA);
+        if (err != ESP_OK) 
+        {
+            std::stringstream msg;
+            msg << "Startup Failure: Camera init error 0x" << std::hex << err;
+            throw std::runtime_error {msg.str()};
+        }
+
+        sensor_t * s = esp_camera_sensor_get();
+        switch (s->id.PID) {
+            case (OV2640_PID):
+                strcpy(camModel, "OV2640");
+            break;
+            case (OV3660_PID):
+                strcpy(camModel, "OV3660");
+            break;
+            case (OV5640_PID):
+                strcpy(camModel, "OV5640");
+            break;
+            default:
+                strcpy(camModel, "Other");
+            break;
+        }
+        LOG_INF("Camera init OK for model %s on board %s", camModel, CAM_BOARD);
+
+        // model specific corrections
+        if (s->id.PID == OV3660_PID) {
+            // initial sensors are flipped vertically and colors are a bit saturated
+            s->set_vflip(s, 1);//flip it back
+            s->set_brightness(s, 1);//up the brightness just a bit
+            s->set_saturation(s, -2);//lower the saturation
+        }
+        // set frame size to configured value
+        char fsizePtr[4];
+        if (retrieveConfigVal("framesize", fsizePtr)) s->set_framesize(s, (framesize_t)(atoi(fsizePtr)));
+        else s->set_framesize(s, FRAMESIZE_SVGA);
   
 #if defined(CAMERA_MODEL_M5STACK_WIDE)
-      s->set_vflip(s, 1);
-      s->set_hmirror(s, 1);
+        s->set_vflip(s, 1);
+        s->set_hmirror(s, 1);
 #endif
   
 #if defined(CAMERA_MODEL_M5STACK_WIDE) || defined(CAMERA_MODEL_M5STACK_ESP32CAM)
-    s->set_vflip(s, 1);
-    s->set_hmirror(s, 1);
+        s->set_vflip(s, 1);
+        s->set_hmirror(s, 1);
 #endif
   
 #if defined(CAMERA_MODEL_ESP32S3_EYE)
-    s->set_vflip(s, 1);
+        s->set_vflip(s, 1);
 #endif
     }
-  }
-  debugMemory("prepCam");
+    debugMemory("prepCam");
 }
 
-void setup() {   
-  logSetup();
-  if (!psramFound()) sprintf(startupFailure, "Startup Failure: Need PSRAM to be enabled");
-  
-//   // prep SD card storage
-//   startStorage();
-  
-//   // Load saved user configuration
-//   loadConfig();
+void setup() 
+{   
+    logSetup();
 
-//   // initialise camera
-//   prepCam();
+    try
+    {
+        if (!psramFound()) 
+            throw std::runtime_error {"Startup Failure: Need PSRAM to be enabled"};
+        
+        // prep SD card storage
+        startStorage();
+        
+        // Load saved user configuration
+        loadConfig();
 
-// #ifdef DEV_ONLY
-//   devSetup();
-// #endif
+        // initialise camera
+        prepCam();
 
-//   // connect wifi or start config AP if router details not available
-//   startWifi();
+        #ifdef DEV_ONLY
+            devSetup();
+        #endif
 
-//   startWebServer();
-//   if (strlen(startupFailure)) LOG_ERR("%s", startupFailure);
-//   else {
-//     // start rest of services
-//     startStreamServer();
-//     prepSMTP(); 
-//     prepPeripherals();
-//     prepMic(); 
-//     prepRecording();
-//     LOG_INF("Camera model %s on board %s ready @ %uMHz", camModel, CAM_BOARD, xclkMhz); 
-//     checkMemory();
-//   }
+        // connect wifi or start config AP if router details not available
+        startWifi();
 
-  initTelemetryReceiver(Serial2);
-  Serial2.begin(115200);
+        // start rest of services
+        startWebServer();
+        startStreamServer();
+        prepSMTP(); 
+        prepPeripherals();
+        prepMic(); 
+        prepRecording();
+        LOG_INF("Camera model %s on board %s ready @ %uMHz", camModel, CAM_BOARD, xclkMhz); 
+        checkMemory();
+
+        // Start receiving telemetry
+        // initTelemetryReceiver(Serial2);
+        // Serial2.begin(115200);
+    }
+    catch (std::exception const& e)
+    {
+        LOG_ERR("%s", e.what());
+        startupFailure = e.what();
+    }
 }
 
 void loop() {

--- a/globals.h
+++ b/globals.h
@@ -32,6 +32,8 @@
 #include <WiFiClient.h>
 #include <WiFiClientSecure.h>
 
+#include <string>
+
 // global mandatory app specific functions, in appSpecific.cpp 
 bool appDataFiles();
 void buildAppJsonString(bool filter);
@@ -72,7 +74,7 @@ void initStatus(int cfgGroup, int delayVal);
 void killWebSocket();
 void listBuff(const uint8_t* b, size_t len); 
 bool listDir(const char* fname, char* jsonBuff, size_t jsonBuffLen, const char* extension);
-bool loadConfig();
+void loadConfig();
 void logLine();
 void logPrint(const char *fmtStr, ...);
 void logSetup();
@@ -98,7 +100,7 @@ float smoothSensor(float latestVal, float smoothedVal, float alpha);
 void startFTPtask();
 void startOTAtask();
 void startSecTimer(bool startTimer);
-bool startStorage();
+void startStorage();
 void startWebServer();
 bool startWifi(bool firstcall = true);
 void stopPing();
@@ -190,7 +192,7 @@ extern bool monitorOpen;
 extern const char* defaultPage_html;
 extern const char* otaPage_html;
 extern SemaphoreHandle_t wsSendMutex;
-extern char startupFailure[];
+extern std::string startupFailure;
 
 extern UBaseType_t uxHighWaterMarkArr[];
 

--- a/setupAssist.cpp
+++ b/setupAssist.cpp
@@ -87,8 +87,17 @@ static bool wgetFile(const char* githubURL, const char* filePath, bool restart =
         return false;
       }
     } 
-    if (restart) {
-      if (loadConfig()) doRestart("config file downloaded");
+    if (restart) 
+    {
+        try
+        {
+            loadConfig();
+            doRestart("config file downloaded");
+        }
+        catch (std::exception const& e)
+        {
+            startupFailure = e.what();
+        }
     }
   } 
   return true;

--- a/utils.cpp
+++ b/utils.cpp
@@ -11,12 +11,15 @@
 
 #include "appGlobals.h"
 
+#include <string>
+
+
 bool dbgVerbose = false;
 bool timeSynchronized = false;
 bool monitorOpen = true;
 bool dataFilesChecked = false;
 // allow any startup failures to be reported via browser for remote devices
-char startupFailure[50] = {0};
+std::string startupFailure;
 
 /************************** Wifi **************************/
 

--- a/webServer.cpp
+++ b/webServer.cpp
@@ -99,11 +99,14 @@ static void displayLog(httpd_req_t *req) {
 
 static esp_err_t indexHandler(httpd_req_t* req) {
   strcpy(inFileName, INDEX_PAGE_PATH);
+  
   // first check if a startup failure needs to be reported
-  if (strlen(startupFailure)) {
-    httpd_resp_set_type(req, "text/html");                        
-    return httpd_resp_send(req, startupFailure, HTTPD_RESP_USE_STRLEN);
+  if (!startupFailure.empty()) 
+  {
+      httpd_resp_set_type(req, "text/html");                        
+      return httpd_resp_send(req, startupFailure.c_str(), HTTPD_RESP_USE_STRLEN);
   }
+
   // Show wifi wizard if not setup, using access point mode  
   if (!fp.exists(INDEX_PAGE_PATH) && WiFi.status() != WL_CONNECTED) {
     // Open a basic wifi setup page


### PR DESCRIPTION
Making error handling in startup functions less chaotic. Some of the startup functions return a `bool` value indicating success or failure that is never checked. Many of them set the global `startupFailure` variable directly to indicate type of the failure. The `startupFailure` variable is also used to check for error condition. Furthermore, `startupFailure` is a plain character buffer of fixed length 50, which can be accidentally overrun by a printing function. 

I improve error handling by throwing a `std::runtime_error` from startup functions in case of failure. There is a single place where these exceptions are caught in the `setup()` function. The error string is extracted from the exception object and copied to the `startupFailure` variable by the exception handler, such that the code relying on `startupFailure` keeps working. The `startupFailure` variable type is changed from `char[50]` to `std::string` to prevent potential buffer overruns.